### PR TITLE
Wecom corp media package add UploadByByte method, unit testing done

### DIFF
--- a/corp/media/media.go
+++ b/corp/media/media.go
@@ -1,6 +1,7 @@
 package media
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -79,6 +80,28 @@ func UploadByURL(mediaType MediaType, filename, url string, result *ResultUpload
 					defer resp.Body.Close()
 
 					if _, err = io.Copy(w, resp.Body); err != nil {
+						return err
+					}
+
+					return nil
+				}),
+			), nil
+		}),
+		wx.WithDecode(func(b []byte) error {
+			return json.Unmarshal(b, result)
+		}),
+	)
+}
+
+// UploadByByte 上传临时素材
+func UploadByByte(mediaType MediaType, filename string, fileByte []byte, result *ResultUpload) wx.Action {
+	return wx.NewPostAction(urls.CorpMediaUpload,
+		wx.WithQuery("type", string(mediaType)),
+		wx.WithUpload(func() (wx.UploadForm, error) {
+			return wx.NewUploadForm(
+				wx.WithFormFile("media", filename, func(w io.Writer) error {
+					f := bytes.NewBuffer(fileByte)
+					if _, err := io.Copy(w, f); err != nil {
 						return err
 					}
 

--- a/corp/media/media_test.go
+++ b/corp/media/media_test.go
@@ -83,6 +83,40 @@ func TestUploadByURL(t *testing.T) {
 	}, result)
 }
 
+func TestUploadByByte(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body: io.NopCloser(bytes.NewReader([]byte(`{
+	"errcode": 0,
+	"errmsg": "ok",
+	"type": "image",
+	"media_id": "1G6nrLmr5EC3MMb_-zK1dDdzmd0p7cNliYu9V5w7o8K0",
+	"created_at": "1380000000"
+}`))),
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock.NewMockHTTPClient(ctrl)
+
+	client.EXPECT().Upload(gomock.AssignableToTypeOf(context.TODO()), "https://qyapi.weixin.qq.com/cgi-bin/media/upload?access_token=ACCESS_TOKEN&type=file", gomock.AssignableToTypeOf(wx.NewUploadForm())).Return(resp, nil)
+
+	cp := corp.New("CORPID")
+	cp.SetClient(wx.WithHTTPClient(client))
+
+	result := new(ResultUpload)
+
+	err := cp.Do(context.TODO(), "ACCESS_TOKEN", UploadByByte(MediaFile, "test.txt", []byte("test123"), result))
+
+	assert.Nil(t, err)
+	assert.Equal(t, &ResultUpload{
+		Type:      MediaImage,
+		MediaID:   "1G6nrLmr5EC3MMb_-zK1dDdzmd0p7cNliYu9V5w7o8K0",
+		CreatedAt: "1380000000",
+	}, result)
+}
+
 func TestUploadImg(t *testing.T) {
 	resp := &http.Response{
 		StatusCode: http.StatusOK,


### PR DESCRIPTION
In a normal server-side file stream call, a pure byte method would be more convenient, without having to store it once first.